### PR TITLE
Format how orders are displayed in CLI

### DIFF
--- a/internal/app/display_orders.go
+++ b/internal/app/display_orders.go
@@ -102,7 +102,7 @@ func (m orderListModel) View() string {
 		if m.selected == i {
 			cursor = ">" // cursor
 		}
-		line := fmt.Sprintf("%s [%s] %s | %s | %s\n", cursor, order.DisplayID, order.State, order.CreatedAt.Format("2006-01-02"), order.Address.CompanyName)
+		line := fmt.Sprintf("%s [%s] %s | %s | %s\n", cursor, order.DisplayID, order.State, order.ShipAfter.Format("2006-01-02"), order.Address.CompanyName)
 		b.WriteString(line)
 	}
 	b.WriteString("\nUse ↑/↓ or j/k to move, Enter to view, q to quit.")

--- a/internal/app/format_orders.go
+++ b/internal/app/format_orders.go
@@ -7,7 +7,7 @@ import (
 
 // FormatOrder returns a formatted string for a single order.
 func FormatOrder(order Order) string {
-	created := order.CreatedAt.Format("2006-01-02 15:04")
+	created := order.CreatedAt.Format("2006-01-02")
 	retailer := order.Address.CompanyName
 	if retailer == "" {
 		retailer = order.Address.Name
@@ -19,12 +19,12 @@ func FormatOrder(order Order) string {
 	}
 
 	s := fmt.Sprintf(
-		"Order ID: %s\nStatus: %s\nRetailer: %s\nCreated: %s\nTotal: $%.2f\n\nItems:\n",
-		order.DisplayID, order.State, retailer, created, float64(totalCents)/100,
+		"Order ID: %s\nStatus: %s\nRetailer: %s\nCreated: %s\nShip By: %s\nTotal: $%.2f\n\nItems:\n",
+		order.DisplayID, order.State, retailer, created, order.ShipAfter.Format("2006-01-02"), float64(totalCents)/100,
 	)
 	for _, item := range order.Items {
-		s += fmt.Sprintf("  - %s (%s) x%d ($%.2f each)\n",
-			item.ProductName, item.Sku, item.Quantity, float64(item.PriceCents)/100)
+		s += fmt.Sprintf("  - %s x%d ($%.2f each) %s\n",
+			item.Sku, item.Quantity, float64(item.PriceCents)/100, item.ProductName)
 	}
 	return s
 }


### PR DESCRIPTION
This pull request updates the order display formatting in both the order list and detailed order view to show the "Ship By" date instead of the creation date, and makes several improvements to the formatting of order details.

Order date display improvements:

* In `internal/app/display_orders.go`, the order list now displays the `ShipAfter` ("Ship By") date instead of the order's creation date.
* In `internal/app/format_orders.go`, the formatted order details now include both the "Created" date and a new "Ship By" date field, using `order.ShipAfter`.
* The "Created" date in formatted order details is now shown without the time component for consistency.

Order detail formatting improvements:

* The order item formatting in `FormatOrder` has been updated to show SKU first, followed by quantity, price, and product name, making the list more concise and readable.