### PR TITLE
Mock client enhancements and GUI improvements

### DIFF
--- a/cmd/gui.go
+++ b/cmd/gui.go
@@ -99,8 +99,8 @@ func RunGUI() {
 							msg := ""
 							for _, p := range payloads {
 								msg += fmt.Sprintf(
-									"  OrderID: %s\n    MakerCostCents: %d\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n",
-									p.OrderID, p.MakerCostCents, p.Carrier, p.TrackingCode, p.ShippingType,
+									"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n",
+									apppkg.OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType,
 								)
 								if showError && p.ErrorMsg != "" {
 									msg += fmt.Sprintf("    SaleSource: %s\n    Error: %s\n\n", p.SaleSource, p.ErrorMsg)
@@ -141,7 +141,9 @@ func RunGUI() {
 						if err != nil {
 							dialog.ShowError(fmt.Errorf("%s", msg), w)
 						} else {
-							scroll := container.NewVScroll(widget.NewLabel(msg))
+							entry := widget.NewMultiLineEntry()
+							entry.SetText(msg)
+							scroll := container.NewVScroll(entry)
 							scroll.SetMinSize(fyne.NewSize(380, 250))
 							dialog.ShowCustom("Success", "OK", scroll, w)
 						}
@@ -203,7 +205,9 @@ func RunGUI() {
 					fyne.Do(func() {
 						progressDialog.Hide()
 						msg := apppkg.FormatOrders(allOrders)
-						scroll := container.NewVScroll(widget.NewLabel(msg))
+						entry := widget.NewMultiLineEntry()
+						entry.SetText(msg)
+						scroll := container.NewVScroll(entry)
 						scroll.SetMinSize(fyne.NewSize(500, 400))
 						dialog.ShowCustom("Orders", "OK", scroll, w)
 					})
@@ -283,7 +287,9 @@ func RunGUI() {
 							return
 						}
 						msg := apppkg.FormatOrder(order)
-						scroll := container.NewVScroll(widget.NewLabel(msg))
+						entry := widget.NewMultiLineEntry()
+						entry.SetText(msg)
+						scroll := container.NewVScroll(entry)
 						scroll.SetMinSize(fyne.NewSize(500, 400))
 						dialog.ShowCustom("Order", "OK", scroll, w)
 					})

--- a/cmd/gui.go
+++ b/cmd/gui.go
@@ -176,7 +176,12 @@ func RunGUI() {
 				progressDialog.Show()
 
 				go func() {
-					client := apppkg.NewFaireClient()
+					var client apppkg.FaireClientInterface
+					if useMock {
+						client = &apppkg.MockFaireClient{Orders: apppkg.MockOrders}
+					} else {
+						client = apppkg.NewFaireClient()
+					}
 					var allOrders []apppkg.Order
 					currPage := 1
 					for {
@@ -273,7 +278,12 @@ func RunGUI() {
 				progressDialog.Show()
 
 				go func() {
-					client := apppkg.NewFaireClient()
+					var client apppkg.FaireClientInterface
+					if useMock {
+						client = &apppkg.MockFaireClient{Orders: apppkg.MockOrders}
+					} else {
+						client = apppkg.NewFaireClient()
+					}
 					resp, err := client.GetOrderByID(orderID, token)
 					fyne.Do(func() {
 						progressDialog.Hide()

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -25,6 +25,9 @@ func init() {
 	processCmd.Flags().StringVar(&failsFlag, "fails", "", "Comma-separated list of shipment indices to fail (mock only)")
 
 	ordersCmd.Flags().StringVar(&statesFlag, "states", "", "Comma-separated list of order states to include (e.g. NEW,DELIVERED)")
+	ordersCmd.Flags().BoolVar(&mockFlag, "mock", false, "Use mock Faire client (no real API calls)")
+
+	orderCmd.Flags().BoolVar(&mockFlag, "mock", false, "Use mock Faire client (no real API calls)")
 }
 
 var processCmd = &cobra.Command{
@@ -59,7 +62,13 @@ var ordersCmd = &cobra.Command{
 	Short: "Get all orders by sale source (21, asc, bjp, bsc, gtg, oat, sm)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client := NewFaireClient()
+		var client FaireClientInterface
+		if mockFlag {
+			// Use shared MockOrders from mock_client.go
+			client = &MockFaireClient{Orders: MockOrders}
+		} else {
+			client = NewFaireClient()
+		}
 		var token string
 		if len(args) == 0 {
 			return fmt.Errorf("sale source is required (21, asc, bjp, bsc, gtg, oat, sm)")
@@ -143,7 +152,13 @@ var orderCmd = &cobra.Command{
 	Short: "Get a single order by sale source (sm or bsc) and ID",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		client := NewFaireClient()
+		var client FaireClientInterface
+		if mockFlag {
+			// Use shared MockOrders from mock_client.go
+			client = &MockFaireClient{Orders: MockOrders}
+		} else {
+			client = NewFaireClient()
+		}
 		if len(args) != 2 {
 			return fmt.Errorf("expected 2 arguments (sale source and order ID), got %d", len(args))
 		}

--- a/internal/app/display_processed.go
+++ b/internal/app/display_processed.go
@@ -38,8 +38,8 @@ func (m processedModel) View() string {
 	} else {
 		for _, p := range m.processed {
 			b.WriteString(fmt.Sprintf(
-				"  OrderID: %s\n    MakerCostCents: %d\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n",
-				p.OrderID, p.MakerCostCents, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource,
+				"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n",
+				OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource,
 			))
 		}
 	}
@@ -49,8 +49,8 @@ func (m processedModel) View() string {
 	} else {
 		for _, p := range m.failed {
 			b.WriteString(fmt.Sprintf(
-				"  OrderID: %s\n    MakerCostCents: %d\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n",
-				p.OrderID, p.MakerCostCents, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource,
+				"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n    Error: %s\n",
+				OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource, p.ErrorMsg,
 			))
 		}
 	}

--- a/internal/app/faire.go
+++ b/internal/app/faire.go
@@ -21,6 +21,8 @@ type FaireClient struct {
 // FaireClientInterface allows mocking of FaireClient for testing
 type FaireClientInterface interface {
 	AddShipment(payload ShipmentPayload, apiToken string) error
+	GetAllOrders(apiToken string, limit int, page int, states string) ([]byte, error)
+	GetOrderByID(PONumber string, apiToken string) ([]byte, error)
 }
 
 type ShipmentRequest struct {

--- a/internal/app/mock_client.go
+++ b/internal/app/mock_client.go
@@ -1,11 +1,37 @@
 package app
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // MockFaireClient implements FaireClientInterface for testing and development
 type MockFaireClient struct {
 	CallCount  int
 	FailOnCall map[int]bool // map of call indices to fail (1-based)
+	Orders     []Order      // mock orders for testing
+}
+
+// MockOrders is a shared set of mock orders for testing/demo
+var MockOrders = []Order{
+	{
+		ID:         "mock123",
+		DisplayID:  "MOCK-ORDER-1",
+		State:      "NEW",
+		RetailerID: "retailer_001",
+	},
+	{
+		ID:         "mock456",
+		DisplayID:  "MOCK-ORDER-2",
+		State:      "PROCESSING",
+		RetailerID: "retailer_002",
+	},
+	{
+		ID:         "mock789",
+		DisplayID:  "MOCK-ORDER-3",
+		State:      "NEW",
+		RetailerID: "retailer_003",
+	},
 }
 
 func (m *MockFaireClient) AddShipment(payload ShipmentPayload, apiToken string) error {
@@ -23,4 +49,32 @@ type MockError struct {
 
 func (e *MockError) Error() string {
 	return e.msg
+}
+
+// GetAllOrders returns mock orders as JSON ([]byte)
+func (m *MockFaireClient) GetAllOrders(apiToken string, limit int, page int, states string) ([]byte, error) {
+	time.Sleep(300 * time.Millisecond) // Simulate network/processing delay
+	m.CallCount++
+	orders := m.Orders
+	if orders == nil {
+		orders = MockOrders
+	}
+	resp := Orders{Page: page, Limit: limit, Orders: orders}
+	return json.Marshal(resp)
+}
+
+// GetOrderByID returns a single mock order as JSON ([]byte)
+func (m *MockFaireClient) GetOrderByID(PONumber string, apiToken string) ([]byte, error) {
+	time.Sleep(300 * time.Millisecond) // Simulate network/processing delay
+	m.CallCount++
+	orders := m.Orders
+	if orders == nil {
+		orders = MockOrders
+	}
+	for _, order := range orders {
+		if order.DisplayID == PONumber || order.ID == PONumber {
+			return json.Marshal(order)
+		}
+	}
+	return nil, &MockError{"order not found"}
 }

--- a/internal/app/process.go
+++ b/internal/app/process.go
@@ -12,6 +12,13 @@ func DisplayIDToOrderID(displayID string) string {
 	return "bo_" + strings.ToLower(displayID)
 }
 
+func OrderIDToDisplayID(orderID string) string {
+	if !strings.HasPrefix(orderID, "bo_") {
+		return orderID // Return as is if it doesn't match expected format
+	}
+	return strings.ToUpper(strings.TrimPrefix(orderID, "bo_"))
+}
+
 func BillingToShippingType(billing string) string {
 	switch billing {
 	case "Consignee":

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current application version.
 // Update this value before each release.
-var Version = "1.1.2"
+var Version = "1.1.3"


### PR DESCRIPTION
This pull request introduces several improvements to the application's mock client support and user interface, making it easier to test and demo order-related features without real API calls. The most significant changes are the addition of a mock Faire client for order retrieval, enhancements to the display of order information, and updates to command-line flags and UI components to support these features.

**Mock client and order retrieval enhancements:**

* Added a `MockFaireClient` implementation of `FaireClientInterface`, with methods `GetAllOrders` and `GetOrderByID` that return mock order data for testing and demos. A shared `MockOrders` dataset is provided for consistency. (`internal/app/mock_client.go`, `internal/app/faire.go`) [[1]](diffhunk://#diff-7a53df95dac910d6a7c8532b27f53fd055320072f66b3d98cccf3080a22cf2e3L3-R34) [[2]](diffhunk://#diff-7a53df95dac910d6a7c8532b27f53fd055320072f66b3d98cccf3080a22cf2e3R53-R80) [[3]](diffhunk://#diff-c08e88598b9229483442eb78e678cd5a398e8fc0d52f99791342bf54ed163bf8R24-R25)
* Updated command-line commands (`ordersCmd` and `orderCmd`) to accept a `--mock` flag, enabling use of the mock client instead of making real API calls. (`internal/app/commands.go`) [[1]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992R28-R30) [[2]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992L62-R71) [[3]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992L146-R161)
* Updated the GUI (`cmd/gui.go`) to support mock mode for order retrieval, using the mock client and data when enabled. (`cmd/gui.go`) [[1]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L177-R184) [[2]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L272-R286)

**Order display and formatting improvements:**

* Introduced a new function `OrderIDToDisplayID` to consistently format and display order IDs in user-facing output. This function is now used when displaying processed and failed orders. (`internal/app/process.go`, `internal/app/display_processed.go`, `cmd/gui.go`) [[1]](diffhunk://#diff-2cae98a3c03461eabf442a1f9cf5f2ee8be0c5fc7cc0bd025e40a2c522c0f03aR15-R21) [[2]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L41-R42) [[3]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L52-R53) [[4]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L102-R103)
* Changed the display of `MakerCostCents` from integer cents to a float with two decimal places (dollars) for improved readability in both CLI and GUI outputs. (`internal/app/display_processed.go`, `cmd/gui.go`) [[1]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L41-R42) [[2]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L52-R53) [[3]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L102-R103)

**GUI usability improvements:**

* Switched order and result dialogs in the GUI from single-line labels to multi-line text entries, allowing users to easily scroll and copy order information. (`cmd/gui.go`) [[1]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L144-R146) [[2]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L206-R215) [[3]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L286-R302)

**Miscellaneous:**

* Bumped the application version to `1.1.3`. (`internal/version/version.go`)