### PR TITLE
Add mock CSV export mode and sale_source column to orders CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This project includes both a command-line interface (CLI) and a graphical user i
 - **Responsive Progress Bar (GUI):** Progress dialogs are shown during all long-running operations, including shipment processing, order fetching, exporting, and self-update.
 - **Get All Orders:** Enter a sale source (`21`, `asc`, `bjp`, `bsc`, `gtg`, `oat`, or `sm`) to fetch and display all orders. Internal pagination is always used; CLI flags for limit and page have been removed.
 - **Get Order By ID:** Enter a sale source and order ID to fetch and display a specific order.
-- **Export NEW Orders to CSV:** Export all new orders for a sale source to a CSV file, including fields like `commission_cents`, `commission_bps`, `item_quantity`, and more.
-- **Test/Mock Mode:** CLI and GUI support mock processing for testing, with options to simulate failures. The GUI now includes a "Use Mock Server" checkbox and a field to specify which shipment indices should fail (e.g., "2,4").
-- **Improved Mock Client:** The mock client now supports both shipment and order operations, including simulating failures for specific shipments and providing mock order data for testing and demos.
+- **Export NEW Orders to CSV:** Export all new orders for a sale source to a CSV file, including fields like `commission_cents`, `commission_bps`, `item_quantity`, `sale_source`, and more.
+- **Test/Mock Mode:** CLI and GUI support mock processing for testing, with options to simulate failures. The GUI now includes a "Use Mock Server" checkbox and a field to specify which shipment indices should fail (e.g., "2,4"). The export command and GUI export now support mock mode, generating a CSV file with only headers (including `sale_source`) and no data.
+- **Improved Mock Client:** The mock client now supports both shipment and order operations, including simulating failures for specific shipments, providing mock order data for testing and demos, and generating mock CSV exports.
 - **Multi-line Dialogs & Order Formatting:** Order and shipment results are now displayed in improved, multi-line dialogs for better readability. Order formatting in both CLI and GUI has been enhanced.
 - **Detailed TUI Feedback:** Both CLI and GUI provide detailed text-based interfaces for viewing processed shipments and orders, including failed shipments.
 - **Native File Dialog & Notifications (GUI):** CSV selection uses the system's native file dialog, and results are shown in scrollable dialogs and system notifications.
@@ -137,15 +137,19 @@ _Get a single order by sale source (`21`, `asc`, `bjp`, `bsc`, `gtg`, `oat`, or 
 #### Export NEW Orders to CSV
 
 ```
-./bin/faire --cli export [sale_source]
+./bin/faire --cli export [sale_source] [--mock]
 ```
 
-_Export all new orders for a sale source to `faire_new_orders.csv`. The CSV includes fields such as `commission_cents`, `commission_bps`, `item_quantity`, and more._
+_Export all new orders for a sale source to `faire_new_orders.csv`. The CSV includes fields such as `commission_cents`, `commission_bps`, `item_quantity`, `sale_source`, and more._
+
+**Flags:**
+
+- `--mock`: Generate a CSV file with only the headers (including `sale_source`), no real API calls or order data.
 
 **Example:**
 
 ```
-./bin/faire --cli export bsc
+./bin/faire --cli export bsc --mock
 ```
 
 **Note:** Ensure the required environment variables (`BSC_API_TOKEN`, `SMD_API_TOKEN`, `C21_API_TOKEN`, `ASC_API_TOKEN`, `BJP_API_TOKEN`, `GTG_API_TOKEN`, `OAT_API_TOKEN`) are set before running commands. For other sale sources, set the corresponding API token environment variable.
@@ -166,8 +170,8 @@ You can also launch the CLI from within the GUI using the "Launch CLI" button.
 2. **Process Shipments CSV:** Click the button and select a CSV file. The app will process the file and show a detailed scrollable dialog and system notification with results, including failed shipments.
 3. **Get All Orders:** Click the button, enter any supported sale source (`21`, `asc`, `bjp`, `bsc`, `gtg`, `oat`, or `sm`), and view the results in a scrollable dialog.
 4. **Get Order By ID:** Click the button, enter the sale source and order ID, and view the order details in a scrollable dialog.
-5. **Export NEW Orders to CSV:** Click the button, enter the sale source, and export all new orders to `faire_new_orders.csv` (includes commission and item details).
-6. **Mock/Test Mode:** The GUI now uses a "Use Mock Server" checkbox and a field to specify which shipment indices should fail (e.g., "2,4").
+5. **Export NEW Orders to CSV:** Click the button, enter the sale source, and export all new orders to `faire_new_orders.csv` (includes commission, item details, and the `sale_source` column). If "Use Mock Server" is checked, the export will generate a CSV file with only the headers (including `sale_source`) and no data.
+6. **Mock/Test Mode:** The GUI now uses a "Use Mock Server" checkbox and a field to specify which shipment indices should fail (e.g., "2,4"). The mock mode applies to shipment processing and CSV export.
 7. **Improved Dialogs & Formatting:** Order and shipment results are now displayed in improved, multi-line dialogs for better readability. Order formatting in both CLI and GUI has been enhanced.
 8. **.env Support:** Both CLI and GUI load API tokens from a `.env` file if present.
 9. **Detailed Results:** All dialogs show detailed results, including failed shipments and all shipment/order fields.

--- a/cmd/gui.go
+++ b/cmd/gui.go
@@ -99,7 +99,7 @@ func RunGUI() {
 							msg := ""
 							for _, p := range payloads {
 								msg += fmt.Sprintf(
-									"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n",
+									"  OrderID: %s\n    ShippingCost: $%.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n",
 									apppkg.OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType,
 								)
 								if showError && p.ErrorMsg != "" {
@@ -237,14 +237,23 @@ func RunGUI() {
 				progressDialog := dialog.NewCustom("Exporting", "Cancel", container.NewVBox(progressLabel, progress), w)
 				progressDialog.Show()
 				go func() {
-					client := apppkg.NewFaireClient()
-					count, err := client.ExportNewOrdersToCSV(saleSource, "faire_new_orders.csv")
+					var err error
+					var msg string
+					if useMock {
+						err = apppkg.WriteMockOrdersCSV("faire_new_orders.csv")
+						msg = "Exported CSV headers to faire_new_orders.csv"
+					} else {
+						client := apppkg.NewFaireClient()
+						var count int
+						count, err = client.ExportNewOrdersToCSV(saleSource, "faire_new_orders.csv")
+						msg = fmt.Sprintf("Exported %d new orders to faire_new_orders.csv", count)
+					}
 					fyne.Do(func() {
 						progressDialog.Hide()
 						if err != nil {
 							dialog.ShowError(fmt.Errorf("export failed: %v", err), w)
 						} else {
-							dialog.ShowInformation("Export Complete", fmt.Sprintf("Exported %d new orders to faire_new_orders.csv", count), w)
+							dialog.ShowInformation("Export Complete", msg, w)
 						}
 					})
 				}()

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -28,6 +28,7 @@ func init() {
 	ordersCmd.Flags().BoolVar(&mockFlag, "mock", false, "Use mock Faire client (no real API calls)")
 
 	orderCmd.Flags().BoolVar(&mockFlag, "mock", false, "Use mock Faire client (no real API calls)")
+	exportCmd.Flags().BoolVar(&mockFlag, "mock", false, "Generate only CSV headers (no real API calls)")
 }
 
 var processCmd = &cobra.Command{
@@ -191,6 +192,13 @@ var exportCmd = &cobra.Command{
 	Short: "Export NEW orders to a CSV file",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if mockFlag {
+			if err := WriteMockOrdersCSV("faire_new_orders.csv"); err != nil {
+				return err
+			}
+			fmt.Printf("Exported CSV headers to faire_new_orders.csv\n")
+			return nil
+		}
 		client := NewFaireClient()
 		count, err := client.ExportNewOrdersToCSV(args[0], "faire_new_orders.csv")
 		if err != nil {

--- a/internal/app/display_processed.go
+++ b/internal/app/display_processed.go
@@ -38,7 +38,7 @@ func (m processedModel) View() string {
 	} else {
 		for _, p := range m.processed {
 			b.WriteString(fmt.Sprintf(
-				"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n",
+				"  OrderID: %s\n    ShippingCost: $%.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n",
 				OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource,
 			))
 		}
@@ -49,7 +49,7 @@ func (m processedModel) View() string {
 	} else {
 		for _, p := range m.failed {
 			b.WriteString(fmt.Sprintf(
-				"  OrderID: %s\n    MakerCostCents: %.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n    Error: %s\n",
+				"  OrderID: %s\n    ShippingCost: $%.2f\n    Carrier: %s\n    TrackingCode: %s\n    ShippingType: %s\n    SaleSource: %s\n    Error: %s\n",
 				OrderIDToDisplayID(p.OrderID), float32(p.MakerCostCents)/100, p.Carrier, p.TrackingCode, p.ShippingType, p.SaleSource, p.ErrorMsg,
 			))
 		}

--- a/internal/app/faire.go
+++ b/internal/app/faire.go
@@ -151,7 +151,7 @@ func (c *FaireClient) ExportNewOrdersToCSV(saleSource, filename string) (int, er
 		"address_country", "address_country_code", "address_company_name",
 		"is_free_shipping", "brand_discounts_includes_free_shipping", "brand_discounts_discount_percentage",
 		"payout_costs_commission_bps", "payout_costs_commission_cents",
-		"item_sku", "item_price_cents", "item_quantity",
+		"item_sku", "item_price_cents", "item_quantity", "sale_source",
 	}
 	if err := writer.Write(header); err != nil {
 		return 0, fmt.Errorf("failed to write CSV header: %w", err)
@@ -192,6 +192,7 @@ func (c *FaireClient) ExportNewOrdersToCSV(saleSource, filename string) (int, er
 				item.Sku,
 				fmt.Sprintf("%.2f", float64(item.PriceCents)/100.0),
 				strconv.Itoa(item.Quantity),
+				strings.ToUpper(saleSource),
 			}
 			if err := writer.Write(row); err != nil {
 				return 0, fmt.Errorf("failed to write CSV row: %w", err)

--- a/internal/app/mock_client.go
+++ b/internal/app/mock_client.go
@@ -1,7 +1,10 @@
 package app
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 )
 
@@ -77,4 +80,29 @@ func (m *MockFaireClient) GetOrderByID(PONumber string, apiToken string) ([]byte
 		}
 	}
 	return nil, &MockError{"order not found"}
+}
+
+// WriteMockOrdersCSV writes only the CSV headers for mock export (no data)
+func WriteMockOrdersCSV(filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("failed to create CSV file: %w", err)
+	}
+	defer file.Close()
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+	header := []string{
+		"id", "display_id", "created_at", "ship_after",
+		"address_name", "address_address1", "address_address2", "address_postal_code",
+		"address_city", "address_state", "address_state_code", "address_phone_number",
+		"address_country", "address_country_code", "address_company_name",
+		"is_free_shipping", "brand_discounts_includes_free_shipping", "brand_discounts_discount_percentage",
+		"payout_costs_commission_bps", "payout_costs_commission_cents",
+		"item_sku", "item_price_cents", "item_quantity",
+		"sale_source",
+	}
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("failed to write CSV header: %w", err)
+	}
+	return nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current application version.
 // Update this value before each release.
-var Version = "1.1.3"
+var Version = "1.2.0"


### PR DESCRIPTION
This pull request adds support for exporting CSV headers in mock/test mode, improves documentation for the export feature, and makes minor enhancements to order and shipment formatting. The most significant changes include updating the export command and GUI to support mock mode (generating a CSV file with only headers, including the new `sale_source` field), updating the documentation to reflect these changes, and improving the display of shipping cost in the UI.

**Mock/Export Functionality Enhancements:**

* Added a `--mock` flag to the CLI `export` command and GUI, allowing users to generate a CSV file with only headers (including the new `sale_source` column) and no data for testing purposes. The mock export is handled by the new `WriteMockOrdersCSV` function. [[1]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992R31) [[2]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992R195-R201) [[3]](diffhunk://#diff-7a53df95dac910d6a7c8532b27f53fd055320072f66b3d98cccf3080a22cf2e3R84-R108) [[4]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839R240-R256)
* Updated the CSV export logic to always include the `sale_source` column in both real and mock exports. [[1]](diffhunk://#diff-c08e88598b9229483442eb78e678cd5a398e8fc0d52f99791342bf54ed163bf8L154-R154) [[2]](diffhunk://#diff-c08e88598b9229483442eb78e678cd5a398e8fc0d52f99791342bf54ed163bf8R195)

**Documentation Updates:**

* Updated `README.md` to document the new `--mock` flag for the export command, describe mock export behavior in both CLI and GUI, and clarify that the `sale_source` field is included in exports. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R152) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L169-R174)

**User Interface Improvements:**

* Changed order and shipment displays in both CLI and GUI to use the label "ShippingCost" (with dollar formatting) instead of "MakerCostCents" for clarity. [[1]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L102-R102) [[2]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L41-R41) [[3]](diffhunk://#diff-3354aa75e4c4b146fcb0452095a2e802034f225fda1387bfe62630ea9d5b77e9L52-R52)

**Version Update:**

* Bumped the application version to `1.2.0`.