### PR TITLE
Add -extldflags=-mwindows to Windows build ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ windows-amd64:
 	@echo "Building for Windows with GOOS=windows, GOARCH=amd64..."
 	$(call MAKE_BIN_DIR)
 	CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC="zig cc -target x86_64-windows" \
-		go build -ldflags="-H=windowsgui" -o bin/$(BINARY)-windows-amd64.exe ./cmd/
+		go build -ldflags="-H=windowsgui -extldflags=-mwindows" -o bin/$(BINARY)-windows-amd64.exe ./cmd/
 
 # Build for Windows (ARM64)
 windows-arm64:
 	@echo "Building for Windows (ARM64) with GOOS=windows, GOARCH=arm64..."
 	$(call MAKE_BIN_DIR)
 	CGO_ENABLED=1 GOOS=windows GOARCH=arm64 CC="zig cc -target aarch64-windows" \
-		go build -ldflags="-H=windowsgui" -o bin/$(BINARY)-windows-arm64.exe ./cmd/
+	    go build -ldflags="-H=windowsgui -extldflags=-mwindows" -o bin/$(BINARY)-windows-arm64.exe ./cmd/
 
 # Build for Linux (AMD64)
 linux-amd64:


### PR DESCRIPTION
This pull request updates the Windows build process in the `Makefile` to improve how executables are linked for both AMD64 and ARM64 architectures. The key change is the addition of the `-extldflags=-mwindows` linker flag, which ensures the resulting executables are properly treated as GUI applications by Windows.

**Build process improvements:**

* Added `-extldflags=-mwindows` to the `go build` command for both `windows-amd64` and `windows-arm64` targets in the `Makefile` to ensure proper GUI application linking on Windows.