### PR TITLE
Trim whitespace from sale source input and bump version to 1.2.1

### DIFF
--- a/cmd/gui.go
+++ b/cmd/gui.go
@@ -164,7 +164,7 @@ func RunGUI() {
 				if !ok {
 					return
 				}
-				saleSource := entry.Text
+				saleSource := strings.TrimSpace(entry.Text)
 				token, err := apppkg.GetToken(saleSource)
 				if err != nil || token == "" {
 					dialog.ShowError(fmt.Errorf("invalid or missing token for sale source '%s'", saleSource), w)
@@ -231,7 +231,7 @@ func RunGUI() {
 				if !ok {
 					return
 				}
-				saleSource := entry.Text
+				saleSource := strings.TrimSpace(entry.Text)
 				progress := widget.NewProgressBarInfinite()
 				progressLabel := widget.NewLabel("Exporting new orders to CSV...")
 				progressDialog := dialog.NewCustom("Exporting", "Cancel", container.NewVBox(progressLabel, progress), w)
@@ -274,7 +274,7 @@ func RunGUI() {
 				if !ok {
 					return
 				}
-				saleSource := saleSourceEntry.Text
+				saleSource := strings.TrimSpace(saleSourceEntry.Text)
 				orderID := orderIDEntry.Text
 				token, err := apppkg.GetToken(saleSource)
 				if err != nil || token == "" {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -76,7 +76,7 @@ var ordersCmd = &cobra.Command{
 		} else if len(args) > 1 {
 			return fmt.Errorf("too many arguments, expected 1 (got %d)", len(args))
 		} else {
-			saleSource := args[0]
+			saleSource := strings.TrimSpace(args[0])
 			var err error
 			token, err = GetToken(saleSource)
 			if err != nil || token == "" {
@@ -163,7 +163,7 @@ var orderCmd = &cobra.Command{
 		if len(args) != 2 {
 			return fmt.Errorf("expected 2 arguments (sale source and order ID), got %d", len(args))
 		}
-		saleSource := args[0]
+		saleSource := strings.TrimSpace(args[0])
 		var token string
 		var err error
 		token, err = GetToken(saleSource)
@@ -199,8 +199,9 @@ var exportCmd = &cobra.Command{
 			fmt.Printf("Exported CSV headers to faire_new_orders.csv\n")
 			return nil
 		}
+		saleSource := strings.TrimSpace(args[0])
 		client := NewFaireClient()
-		count, err := client.ExportNewOrdersToCSV(args[0], "faire_new_orders.csv")
+		count, err := client.ExportNewOrdersToCSV(saleSource, "faire_new_orders.csv")
 		if err != nil {
 			return err
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current application version.
 // Update this value before each release.
-var Version = "1.2.0"
+var Version = "1.2.1"


### PR DESCRIPTION
This pull request focuses on improving input handling for the `saleSource` parameter throughout both the GUI and CLI code paths, ensuring that any leading or trailing whitespace is removed before further processing. This helps prevent errors caused by accidental spaces in user input. Additionally, the application version is incremented to reflect this improvement.

Input sanitization improvements:

* All instances where `saleSource` is read from user input (in both GUI and CLI flows) now use `strings.TrimSpace()` to remove whitespace before processing or passing to token retrieval and export functions. [[1]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L167-R167) [[2]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L234-R234) [[3]](diffhunk://#diff-167af955ddfd556a77d7100d6a9c7f0fc61272bf740a719848c358c976972839L277-R277) [[4]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992L79-R79) [[5]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992L166-R166) [[6]](diffhunk://#diff-ae80f84641612606d3476965d3ee90acfdc3a314fdcd6771a380a3a3f47ec992R202-R204)

Version update:

* Updated the application version from `1.2.0` to `1.2.1` in `internal/version/version.go` to reflect these changes.